### PR TITLE
Force new resource when path and path prefix change

### DIFF
--- a/secrethub/data_source_secret.go
+++ b/secrethub/data_source_secret.go
@@ -37,7 +37,8 @@ func dataSourceSecretRead(d *schema.ResourceData, m interface{}) error {
 	provider := m.(providerMeta)
 	client := *provider.client
 
-	path := getSecretPath(d, &provider)
+	synchronizePathPrefix(d, &provider)
+	path := getSecretPath(d)
 
 	secret, err := client.Secrets().Versions().GetWithData(path)
 	if err != nil {


### PR DESCRIPTION
Marked the `path` and `path_prefix` with `ForceNew`. When any of these fields change, Terraform will destroy the old secret on SecretHub and create a new one on the new path.