### PR TITLE
Rename secret resource and data source fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ resource "secrethub_secret" "db_password" {
 
 resource "secrethub_secret" "db_username" {
   path = "my-org/my-repo/db/username"
-  data = "db-user"
+  value = "db-user"
 }
 
 resource "aws_db_instance" "default" {
@@ -52,8 +52,8 @@ resource "aws_db_instance" "default" {
   engine_version       = "5.7"
   instance_class       = "db.t2.micro"
   name                 = "mydb"
-  username             = "${secrethub_secret.db_username.data}"
-  password             = "${secrethub_secret.db_password.data}"
+  username             = "${secrethub_secret.db_username.value}"
+  password             = "${secrethub_secret.db_password.value}"
   parameter_group_name = "default.mysql5.7"
 }
 ```

--- a/examples/rds.tf
+++ b/examples/rds.tf
@@ -26,13 +26,13 @@ resource "secrethub_secret" "db_password" {
 
   generate {
     length  = 22
-    symbols = true
+    use_symbols = true
   }
 }
 
 resource "secrethub_secret" "db_username" {
   path = "db/username"
-  data = "db-user"
+  value = "db-user"
 }
 
 resource "aws_db_instance" "default" {
@@ -42,7 +42,7 @@ resource "aws_db_instance" "default" {
   engine_version       = "5.7"
   instance_class       = "db.t2.micro"
   name                 = "mydb"
-  username             = "${secrethub_secret.db_username.data}"
-  password             = "${secrethub_secret.db_password.data}"
+  username             = "${secrethub_secret.db_username.value}"
+  password             = "${secrethub_secret.db_password.value}"
   parameter_group_name = "default.mysql5.7"
 }

--- a/secrethub/data_source_secret.go
+++ b/secrethub/data_source_secret.go
@@ -23,7 +23,7 @@ func dataSourceSecret() *schema.Resource {
 				Computed:    true,
 				Description: "The version of the secret.",
 			},
-			"data": {
+			"value": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Sensitive:   true,
@@ -44,7 +44,7 @@ func dataSourceSecretRead(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 
-	d.Set("data", string(secret.Data))
+	d.Set("value", string(secret.Data))
 	d.Set("version", secret.Version)
 
 	d.SetId(string(path))

--- a/secrethub/data_source_secret_test.go
+++ b/secrethub/data_source_secret_test.go
@@ -11,7 +11,7 @@ func TestAccDataSourceSecret_absPath(t *testing.T) {
 	config := fmt.Sprintf(`
 		resource "secrethub_secret" "%v" {
 			path = "%v"
-			data = "secretpassword"
+			value = "secretpassword"
 		}
 
 		data "secrethub_secret" "%v" {
@@ -33,7 +33,7 @@ func TestAccDataSourceSecret_absPath(t *testing.T) {
 					),
 					resource.TestCheckResourceAttr(
 						fmt.Sprintf("data.secrethub_secret.%v", testAcc.secretName),
-						"data",
+						"value",
 						"secretpassword",
 					),
 				),
@@ -46,7 +46,7 @@ func TestAccDataSourceSecret_absPathVersioned(t *testing.T) {
 	configInit := fmt.Sprintf(`
 		resource "secrethub_secret" "%v" {
 			path = "%v"
-			data = "secretpasswordv1"
+			value = "secretpasswordv1"
 		}
 
 		data "secrethub_secret" "%v" {
@@ -57,7 +57,7 @@ func TestAccDataSourceSecret_absPathVersioned(t *testing.T) {
 	configVersioned := fmt.Sprintf(`
 		resource "secrethub_secret" "%v" {
 			path = "%v"
-			data = "secretpasswordv2"
+			value = "secretpasswordv2"
 		}
 
 		data "secrethub_secret" "%v" {
@@ -74,7 +74,7 @@ func TestAccDataSourceSecret_absPathVersioned(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						fmt.Sprintf("data.secrethub_secret.%v", testAcc.secretName),
-						"data",
+						"value",
 						"secretpasswordv1",
 					),
 				),
@@ -84,7 +84,7 @@ func TestAccDataSourceSecret_absPathVersioned(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						fmt.Sprintf("data.secrethub_secret.%v", testAcc.secretName),
-						"data",
+						"value",
 						"secretpasswordv1",
 					),
 				),
@@ -101,7 +101,7 @@ func TestAccDataSourceSecret_prefPath(t *testing.T) {
 
 		resource "secrethub_secret" "%v" {
 			path = "%v"
-			data = "secretpassword"
+			value = "secretpassword"
 		}
 
 		data "secrethub_secret" "%v" {
@@ -118,7 +118,7 @@ func TestAccDataSourceSecret_prefPath(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						fmt.Sprintf("data.secrethub_secret.%v", testAcc.secretName),
-						"data",
+						"value",
 						"secretpassword",
 					),
 				),

--- a/secrethub/resource_secret_test.go
+++ b/secrethub/resource_secret_test.go
@@ -13,7 +13,7 @@ func TestAccResourceSecret_writeAbsPath(t *testing.T) {
 	config := fmt.Sprintf(`
 		resource "secrethub_secret" "%v" {
 			path = "%v"
-			data = "secretpassword"
+			value = "secretpassword"
 		}
 	`, testAcc.secretName, testAcc.path)
 
@@ -39,7 +39,7 @@ func TestAccResourceSecret_writePrefPath(t *testing.T) {
 
 		resource "secrethub_secret" "%v" {
 			path = "%v/%v"
-			data = "secretpassword"
+			value = "secretpassword"
 		}
 	`, testAcc.namespace, testAcc.secretName, testAcc.repository, testAcc.secretName)
 
@@ -66,7 +66,7 @@ func TestAccResourceSecret_writePrefPathOverride(t *testing.T) {
 		resource "secrethub_secret" "%v" {
 			path_prefix = "%v"
 			path = "%v/%v"
-			data = "secretpassword"
+			value = "secretpassword"
 		}
 	`, testAcc.secretName, testAcc.namespace, testAcc.repository, testAcc.secretName)
 
@@ -113,8 +113,8 @@ func TestAccResourceSecret_generate(t *testing.T) {
 				Config: configInit,
 				Check: resource.ComposeTestCheckFunc(
 					checkSecretResourceState(testAcc, func(s *terraform.InstanceState) error {
-						if len(s.Attributes["data"]) != 16 {
-							return fmt.Errorf("expected 'data' to contain a 16 char secret")
+						if len(s.Attributes["value"]) != 16 {
+							return fmt.Errorf("expected 'value' to contain a 16 char secret")
 						}
 						return nil
 					}),
@@ -125,8 +125,8 @@ func TestAccResourceSecret_generate(t *testing.T) {
 				Config: configLengthUpdate,
 				Check: resource.ComposeTestCheckFunc(
 					checkSecretResourceState(testAcc, func(s *terraform.InstanceState) error {
-						if len(s.Attributes["data"]) != 32 {
-							return fmt.Errorf("expected 'data' to contain newly generated 32 char secret")
+						if len(s.Attributes["value"]) != 32 {
+							return fmt.Errorf("expected 'value' to contain newly generated 32 char secret")
 						}
 						return nil
 					}),
@@ -141,7 +141,7 @@ func TestAccResourceSecret_deleteDetection(t *testing.T) {
 	config := fmt.Sprintf(`
 		resource "secrethub_secret" "%v" {
 			path = "%v"
-			data = "secretpassword"
+			value = "secretpassword"
 		}
 	`, testAcc.secretName, testAcc.path)
 
@@ -169,7 +169,7 @@ func TestAccResourceSecret_import(t *testing.T) {
 	config := fmt.Sprintf(`
 		resource "secrethub_secret" "%v" {
 			path = "%v"
-			data = "secretpassword"
+			value = "secretpassword"
 		}
 	`, testAcc.secretName, testAcc.path)
 

--- a/website/docs/d/secrethub_secret.html.markdown
+++ b/website/docs/d/secrethub_secret.html.markdown
@@ -27,5 +27,5 @@ data "secrethub_secret" "db_password" {
 
 In addition to all arguments above, the following attributes are exported:
 
-* `data` - The secret contents.
+* `value` - The secret contents.
 * `version` - The version of the secret.

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -23,7 +23,7 @@ provider "secrethub" {
 
 resource "secrethub_secret" "db_password" {
   path = "db_password"
-  data = "mypassword"
+  value = "mypassword"
 }
 ```
 

--- a/website/docs/r/secrethub_secret.html.markdown
+++ b/website/docs/r/secrethub_secret.html.markdown
@@ -17,7 +17,7 @@ To write a secret:
 ```hcl
 resource "secrethub_secret" "ssh_key" {
   path = "my_org/my_repo/ssh_key"
-  data = "${file("/path/to/ssh/key")}"
+  value = "${file("/path/to/ssh/key")}"
 }
 ```
 
@@ -39,8 +39,8 @@ The following arguments are supported:
 
 * `path` - (Required) The path where the secret will be stored.
 * `path_prefix` - (Optional) Overrides the `path_prefix` defined in the provider.
-* `data` - (Optional) The secret contents. Either `data` or `generate` must be defined.
-* `generate` - (Optional) Settings for autogenerating a secret. Either `data` or `generate` must be defined.
+* `value` - (Optional) The secret contents. Either `value` or `generate` must be defined.
+* `generate` - (Optional) Settings for autogenerating a secret. Either `value` or `generate` must be defined.
 
 Nested `generate` blocks have the following structure:
 


### PR DESCRIPTION
Now that we still easily can:
* `data` becomes `value`
* `symbols` becomes `use_symbols`