### PR TITLE
Use terraform-provider-secrethub_vX.Y.Z as binary name

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,7 +1,7 @@
 project_name: terraform-provider-secrethub
 
 builds:
-  - binary: "{{ .ProjectName }}"
+  - binary: "{{ .ProjectName }}_{{ .Tag }}"
     env:
       - CGO_ENABLED=0
     goos:


### PR DESCRIPTION
This is the convention as documented here:
https://www.terraform.io/docs/configuration/providers.html#plugin-names-and-versions