### PR TITLE
Add service resource

### DIFF
--- a/secrethub/provider.go
+++ b/secrethub/provider.go
@@ -35,6 +35,7 @@ func Provider() terraform.ResourceProvider {
 		ResourcesMap: map[string]*schema.Resource{
 			"secrethub_secret":      resourceSecret(),
 			"secrethub_access_rule": resourceAccessRule(),
+			"secrethub_service":     resourceService(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"secrethub_secret": dataSourceSecret(),

--- a/secrethub/resource_access_rule_test.go
+++ b/secrethub/resource_access_rule_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -37,7 +38,7 @@ func TestAccResourceAccessRule_create(t *testing.T) {
 
 func TestAccessRuleForService(t *testing.T) {
 	repoPath := testAcc.namespace + "/" + testAcc.repository
-	serviceDescription := "test access rule for service"
+	serviceDescription := "TestAccessRuleForService " + acctest.RandString(30)
 	permission := "read"
 
 	config := fmt.Sprintf(`

--- a/secrethub/resource_access_rule_test.go
+++ b/secrethub/resource_access_rule_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccResourceAccessRule_create(t *testing.T) {
+func TestAccResourceAccessRule(t *testing.T) {
 	repoPath := testAcc.namespace + "/" + testAcc.repository
 	accountName := testAcc.secondAccountName
 	permission := "read"
@@ -36,7 +36,7 @@ func TestAccResourceAccessRule_create(t *testing.T) {
 	})
 }
 
-func TestAccessRuleForService(t *testing.T) {
+func TestAccAccessRuleForService(t *testing.T) {
 	repoPath := testAcc.namespace + "/" + testAcc.repository
 	serviceDescription := "TestAccessRuleForService " + acctest.RandString(30)
 	permission := "read"

--- a/secrethub/resource_access_rule_test.go
+++ b/secrethub/resource_access_rule_test.go
@@ -74,7 +74,7 @@ func checkAccessRuleExistsRemotely(path string, account string, permission strin
 
 		accessRule, err := client.AccessRules().Get(path, account)
 		if err != nil {
-			return fmt.Errorf("cannot get created error: %s", err)
+			return fmt.Errorf("cannot get created access rule: %s", err)
 		}
 
 		actual := accessRule.Permission.String()

--- a/secrethub/resource_service.go
+++ b/secrethub/resource_service.go
@@ -31,11 +31,6 @@ func resourceService() *schema.Resource {
 				Sensitive:   true,
 				Description: "The credential of the service account.",
 			},
-			"id": {
-				Type: schema.TypeString,
-				Computed: true,
-				Description: "A unique identifier for the service.",
-			},
 		},
 	}
 }
@@ -65,8 +60,6 @@ func resourceServiceCreate(d *schema.ResourceData, m interface{}) error {
 	if err != nil {
 		return err
 	}
-
-	err = d.Set("id", service.ServiceID)
 
 	return nil
 }

--- a/secrethub/resource_service.go
+++ b/secrethub/resource_service.go
@@ -1,0 +1,106 @@
+package secrethub
+
+import (
+	"github.com/secrethub/secrethub-go/internals/api"
+	"github.com/secrethub/secrethub-go/pkg/secrethub/credentials"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceService() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceServiceCreate,
+		Read:   resourceServiceRead,
+		Delete: resourceServiceDelete,
+		Schema: map[string]*schema.Schema{
+			"repo": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The path of the repository on which the service operates.",
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "A description of the service so others will recognize it.",
+			},
+			"credential": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Sensitive:   true,
+				Description: "The credential of the service account.",
+			},
+			"id": {
+				Type: schema.TypeString,
+				Computed: true,
+				Description: "A unique identifier for the service.",
+			},
+		},
+	}
+}
+
+func resourceServiceCreate(d *schema.ResourceData, m interface{}) error {
+	provider := m.(providerMeta)
+	client := *provider.client
+
+	repo := d.Get("repo").(string)
+	description := d.Get("description").(string)
+
+	credential := credentials.CreateKey()
+
+	service, err := client.Services().Create(repo, description, credential)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(service.ServiceID)
+
+	exported, err := credential.Export()
+	if err != nil {
+		return err
+	}
+
+	err = d.Set("credential", string(exported))
+	if err != nil {
+		return err
+	}
+
+	err = d.Set("id", service.ServiceID)
+
+	return nil
+}
+
+func resourceServiceRead(d *schema.ResourceData, m interface{}) error {
+	provider := m.(providerMeta)
+	client := *provider.client
+
+	remote, err := client.Services().Get(d.Id())
+	if err == api.ErrServiceNotFound {
+		// The service account was deleted outside of the current Terraform workspace, so invalidate this resource
+		d.SetId("")
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	err = d.Set("description", remote.Description)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func resourceServiceDelete(d *schema.ResourceData, m interface{}) error {
+	provider := m.(providerMeta)
+	client := *provider.client
+
+	_, err := client.Services().Delete(d.Id())
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/secrethub/resource_service_test.go
+++ b/secrethub/resource_service_test.go
@@ -1,0 +1,51 @@
+package secrethub
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccResourceService_create(t *testing.T) {
+	repoPath := testAcc.namespace + "/" + testAcc.repository
+
+	config := fmt.Sprintf(`
+		resource "secrethub_service" "test" {
+			repo = "%s"
+		}
+	`, repoPath)
+
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		PreCheck:  testAccPreCheck(t),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					checkServiceExistsRemotely(repoPath, ""),
+				),
+			},
+		},
+	})
+}
+
+func checkServiceExistsRemotely(path string, description string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := *testAccProvider.Meta().(providerMeta).client
+
+		services, err := client.Services().List(path)
+		if err != nil {
+			return fmt.Errorf("cannot list services: %s", err)
+		}
+
+		for _, service := range services {
+			if service.Description == description {
+				return nil
+			}
+		}
+
+		return fmt.Errorf("expected service on repo %s with description \"%s\"", path, description)
+	}
+}

--- a/secrethub/resource_service_test.go
+++ b/secrethub/resource_service_test.go
@@ -10,12 +10,14 @@ import (
 
 func TestAccResourceService_create(t *testing.T) {
 	repoPath := testAcc.namespace + "/" + testAcc.repository
+	serviceDescription := ""
 
 	config := fmt.Sprintf(`
 		resource "secrethub_service" "test" {
 			repo = "%s"
+			description = "%s"
 		}
-	`, repoPath)
+	`, repoPath, serviceDescription)
 
 	resource.Test(t, resource.TestCase{
 		Providers: testAccProviders,
@@ -24,7 +26,7 @@ func TestAccResourceService_create(t *testing.T) {
 			{
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
-					checkServiceExistsRemotely(repoPath, ""),
+					checkServiceExistsRemotely(repoPath, serviceDescription),
 				),
 			},
 		},

--- a/secrethub/resource_service_test.go
+++ b/secrethub/resource_service_test.go
@@ -4,13 +4,14 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccResourceService_create(t *testing.T) {
 	repoPath := testAcc.namespace + "/" + testAcc.repository
-	serviceDescription := ""
+	serviceDescription := "TestAccResourceService_create " + acctest.RandString(30)
 
 	config := fmt.Sprintf(`
 		resource "secrethub_service" "test" {

--- a/secrethub/resource_service_test.go
+++ b/secrethub/resource_service_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccResourceService_create(t *testing.T) {
+func TestAccResourceService(t *testing.T) {
 	repoPath := testAcc.namespace + "/" + testAcc.repository
 	serviceDescription := "TestAccResourceService_create " + acctest.RandString(30)
 

--- a/website/docs/r/service.html.markdown
+++ b/website/docs/r/service.html.markdown
@@ -1,0 +1,24 @@
+---
+layout: "secrethub"
+page_title: "Resource: secrethub_service"
+sidebar_current: "docs-secrethub-resource-service"
+description: |-
+  Creates and manages service accounts
+---
+
+# Resource: secrethub_service
+
+This resource allows you to manage a service account - an account for machines.
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `description` - (Optional) A description of the service so others will recognize it.
+* `repo` - (Required) The path of the repository on which the service operates.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `credential` - The credential of the service account.

--- a/website/secrethub.erb
+++ b/website/secrethub.erb
@@ -25,6 +25,7 @@
           <ul class="nav nav-visible">
             <li<%= sidebar_current("docs-secrethub-resource-secret") %>>
               <a href="/docs/providers/secrethub/r/secret.html">secrethub_secret</a>
+              <a href="/docs/providers/secrethub/r/service.html">secrethub_service</a>
             </li>
           </ul>
         </li>

--- a/website/secrethub.erb
+++ b/website/secrethub.erb
@@ -25,8 +25,10 @@
           <ul class="nav nav-visible">
             <li<%= sidebar_current("docs-secrethub-resource-secret") %>>
               <a href="/docs/providers/secrethub/r/secret.html">secrethub_secret</a>
-              <a href="/docs/providers/secrethub/r/service.html">secrethub_service</a>
             </li>
+            <li<%= sidebar_current("docs-secrethub-resource-service") %>>
+			  <a href="/docs/providers/secrethub/r/service.html">secrethub_service</a>
+			</li>
           </ul>
         </li>
 


### PR DESCRIPTION
The service resource can be used to create service accounts. These
can be used by machines (VM, container etc.) to access the secrets
an application needs.

The access_rule resource can be used to give the service access
to secrets.