### PR TITLE
Add secrethub_service_aws resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ To run the [acceptance tests](https://www.terraform.io/docs/extend/testing/accep
 * `SECRETHUB_CREDENTIAL` - a SecretHub credential.
 * `SECRETHUB_TF_ACC_NAMESPACE` - a namespace registered on SecretHub. Make sure `SECRETHUB_CREDENTIAL` has admin access.
 * `SECRETHUB_TF_ACC_REPOSITORY` - a repository within `SECRETHUB_TF_ACC_NAMESPACE` to be used in the acceptance tests. Make sure `SECRETHUB_CREDENTIAL` has admin access.
+* `SECRETHUB_TF_ACC_SECOND_ACCOUNT_NAME` - an account other than the authenticated account, that is a member of the repository. It will be used to test access rules.
+* `SECRETHUB_TF_ACC_AWS_ROLE` - an AWS IAM role to use for testing AWS service accounts. The role should have decrypt permission on the key in `SECRETHUB_TF_ACC_AWS_KMS_KEY`.
+* `SECRETHUB_TF_ACC_AWS_KMS_KEY` - an AWS KMS key to use for testing AWS service accounts. The authenticated AWS user or role should have encrypt permission on this key and the `SECRETHUB_TF_ACC_AWS_ROLE` should have decrypt permission.
 
 With the environment variables properly set up, run:
 

--- a/secrethub/provider.go
+++ b/secrethub/provider.go
@@ -36,6 +36,7 @@ func Provider() terraform.ResourceProvider {
 			"secrethub_secret":      resourceSecret(),
 			"secrethub_access_rule": resourceAccessRule(),
 			"secrethub_service":     resourceService(),
+			"secrethub_service_aws": resourceServiceAWS(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"secrethub_secret": dataSourceSecret(),

--- a/secrethub/provider_test.go
+++ b/secrethub/provider_test.go
@@ -16,6 +16,8 @@ const (
 	envNamespace         = "SECRETHUB_TF_ACC_NAMESPACE"
 	envRepo              = "SECRETHUB_TF_ACC_REPOSITORY"
 	envSecondAccountName = "SECRETHUB_TF_ACC_SECOND_ACCOUNT_NAME"
+	envAWSKMSKey         = "SECRETHUB_TF_ACC_AWS_KMS_KEY"
+	envAWSRole           = "SECRETHUB_TF_ACC_AWS_ROLE"
 )
 
 var testAccProviders map[string]terraform.ResourceProvider
@@ -29,11 +31,13 @@ type testAccValues struct {
 	secondAccountName string
 	path              string
 	pathErr           error
+	awsKmsKey         string
+	awsRole           string
 }
 
 func (testAccValues) validate() error {
-	if testAcc.namespace == "" || testAcc.repository == "" || testAcc.secondAccountName == "" {
-		return fmt.Errorf("the following environment variables need to be set: %s, %s, %s, %s", envCredential, envNamespace, envRepo, envSecondAccountName)
+	if testAcc.namespace == "" || testAcc.repository == "" || testAcc.secondAccountName == "" || testAcc.awsKmsKey == "" || testAcc.awsRole == "" {
+		return fmt.Errorf("the following environment variables need to be set: %s, %s, %s, %s, %s, %s", envCredential, envNamespace, envRepo, envSecondAccountName, envAWSKMSKey, envAWSRole)
 	}
 	return testAcc.pathErr
 }
@@ -49,6 +53,8 @@ func init() {
 		repository:        os.Getenv(envRepo),
 		secondAccountName: os.Getenv(envSecondAccountName),
 		secretName:        "test_acc_secret",
+		awsKmsKey:         os.Getenv(envAWSKMSKey),
+		awsRole:           os.Getenv(envAWSRole),
 	}
 
 	testAcc.path = newCompoundSecretPath(testAcc.namespace, testAcc.repository, testAcc.secretName)

--- a/secrethub/resource_service_aws.go
+++ b/secrethub/resource_service_aws.go
@@ -1,0 +1,72 @@
+package secrethub
+
+import (
+	"fmt"
+
+	"github.com/secrethub/secrethub-go/pkg/secrethub/credentials"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceServiceAWS() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceServiceAWSCreate,
+		Read:   resourceServiceRead,
+		Delete: resourceServiceDelete,
+		Schema: map[string]*schema.Schema{
+			"repo": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The path of the repository on which the service operates.",
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "A description of the service so others will recognize it.",
+			},
+			"kms_key": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The ARN of the KMS-key to be used for encrypting the service's account key.",
+			},
+			"role": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The role name or ARN of the IAM role that should have access to this service account.",
+			},
+		},
+	}
+}
+
+func resourceServiceAWSCreate(d *schema.ResourceData, m interface{}) error {
+	provider := m.(providerMeta)
+	client := *provider.client
+
+	repo := d.Get("repo").(string)
+	description := d.Get("description").(string)
+	kmsKey := d.Get("kms_key").(string)
+	role := d.Get("role").(string)
+
+	cfg := aws.NewConfig()
+
+	kmsKeyARN, err := arn.Parse(kmsKey)
+	if err != nil {
+		return fmt.Errorf("the provider kms key is not a valid ARN: %s", err)
+	}
+	cfg = cfg.WithRegion(kmsKeyARN.Region)
+
+	service, err := client.Services().Create(repo, description, credentials.CreateAWS(kmsKey, role, cfg))
+	if err != nil {
+		return err
+	}
+
+	d.SetId(service.ServiceID)
+
+	return nil
+}

--- a/secrethub/resource_service_aws.go
+++ b/secrethub/resource_service_aws.go
@@ -28,7 +28,7 @@ func resourceServiceAWS() *schema.Resource {
 				ForceNew:    true,
 				Description: "A description of the service so others will recognize it.",
 			},
-			"kms_key": {
+			"kms_key_arn": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,

--- a/secrethub/resource_service_aws.go
+++ b/secrethub/resource_service_aws.go
@@ -50,7 +50,7 @@ func resourceServiceAWSCreate(d *schema.ResourceData, m interface{}) error {
 
 	repo := d.Get("repo").(string)
 	description := d.Get("description").(string)
-	kmsKey := d.Get("kms_key").(string)
+	kmsKey := d.Get("kms_key_arn").(string)
 	role := d.Get("role").(string)
 
 	cfg := aws.NewConfig()

--- a/secrethub/resource_service_aws_test.go
+++ b/secrethub/resource_service_aws_test.go
@@ -16,10 +16,10 @@ func TestAccResourceServiceAWS(t *testing.T) {
 
 	config := fmt.Sprintf(`
 		resource "secrethub_service_aws" "test" {
-			repo        = "%s"
-			kms_key_arn = "%s"
-			role        = "%s"
-			description = "%s"
+			repo    	= "%s"
+			kms_key_arn	= "%s"
+			role    	= "%s"
+			description	= "%s"
 		}
 	`, repoPath, kmsKey, role, description)
 

--- a/secrethub/resource_service_aws_test.go
+++ b/secrethub/resource_service_aws_test.go
@@ -1,0 +1,38 @@
+package secrethub
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccResourceServiceAWS(t *testing.T) {
+	repoPath := testAcc.namespace + "/" + testAcc.repository
+	kmsKey := testAcc.awsKmsKey
+	role := testAcc.awsRole
+	description := "TestAccResourceServiceAWS " + acctest.RandString(30)
+
+	config := fmt.Sprintf(`
+		resource "secrethub_service_aws" "test" {
+			repo    	= "%s"
+			kms_key 	= "%s"
+			role    	= "%s"
+			description = "%s"
+		}
+	`, repoPath, kmsKey, role, description)
+
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		PreCheck:  testAccPreCheck(t),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					checkServiceExistsRemotely(repoPath, description),
+				),
+			},
+		},
+	})
+}

--- a/secrethub/resource_service_aws_test.go
+++ b/secrethub/resource_service_aws_test.go
@@ -16,9 +16,9 @@ func TestAccResourceServiceAWS(t *testing.T) {
 
 	config := fmt.Sprintf(`
 		resource "secrethub_service_aws" "test" {
-			repo    	= "%s"
-			kms_key 	= "%s"
-			role    	= "%s"
+			repo        = "%s"
+			kms_key_arn = "%s"
+			role        = "%s"
 			description = "%s"
 		}
 	`, repoPath, kmsKey, role, description)

--- a/website/docs/r/service_aws.html.markdown
+++ b/website/docs/r/service_aws.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 This resource allows you to manage a service account that is tied to an AWS IAM role.
 
-The native AWS identity provider uses a combination of AWS IAM and AWS KMS to provide access to SecretHub for any service running on AWS (e.g. EC2, Lambda or ECS).
+The native AWS identity provider uses a combination of AWS IAM and AWS KMS to provide access to SecretHub for any service running on AWS (e.g. EC2, Lambda or ECS) without needing a SecretHub credential.
 
 ## Argument Reference
 

--- a/website/docs/r/service_aws.html.markdown
+++ b/website/docs/r/service_aws.html.markdown
@@ -17,7 +17,7 @@ The native AWS identity provider uses a combination of AWS IAM and AWS KMS to pr
 The following arguments are supported:
 
 * `description` - (Optional) A description of the service so others will recognize it.
-* `kms_key` - (Required) The ARN of the KMS-key to be used for encrypting the service's account key.
+* `kms_key_arn` - (Required) The ARN of the KMS-key to be used for encrypting the service's account key.
 * `repo` - (Required) The path of the repository on which the service operates.
 * `role` - (Required) The role name or ARN of the IAM role that should have access to this service account.
 

--- a/website/docs/r/service_aws.html.markdown
+++ b/website/docs/r/service_aws.html.markdown
@@ -1,0 +1,23 @@
+---
+layout: "secrethub"
+page_title: "Resource: secrethub_service_aws"
+sidebar_current: "docs-secrethub-resource-service-aws"
+description: |-
+  Creates and manages service accounts tied to an AWS IAM role.
+---
+
+# Resource: secrethub_service_aws
+
+This resource allows you to manage a service account that is tied to an AWS IAM role.
+
+The native AWS identity provider uses a combination of AWS IAM and AWS KMS to provide access to SecretHub for any service running on AWS (e.g. EC2, Lambda or ECS).
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `description` - (Optional) A description of the service so others will recognize it.
+* `kms_key` - (Required) The ARN of the KMS-key to be used for encrypting the service's account key.
+* `repo` - (Required) The path of the repository on which the service operates.
+* `role` - (Required) The role name or ARN of the IAM role that should have access to this service account.
+

--- a/website/secrethub.erb
+++ b/website/secrethub.erb
@@ -27,11 +27,13 @@
               <a href="/docs/providers/secrethub/r/secret.html">secrethub_secret</a>
             </li>
             <li<%= sidebar_current("docs-secrethub-resource-service") %>>
-			  <a href="/docs/providers/secrethub/r/service.html">secrethub_service</a>
-			</li>
+              <a href="/docs/providers/secrethub/r/service.html">secrethub_service</a>
+            </li>
+			<li<%= sidebar_current("docs-secrethub-resource-service-aws") %>>
+              <a href="/docs/providers/secrethub/r/service_aws.html">secrethub_service_aws</a>
+            </li>
           </ul>
         </li>
-
       </ul>
     </div>
   <% end %>


### PR DESCRIPTION
The secrethub_service_aws resource lets you create and manage
service accounts that are tied to an AWS IAM role.

They can be used by your appliations by assuming the role and
setting SECRETHUB_IDENTITY_PROVIDER=aws