### PR TITLE
Add deprecated path_prefix arg back to website with a deprecation notice

### DIFF
--- a/website/docs/d/secret.html.markdown
+++ b/website/docs/d/secret.html.markdown
@@ -21,6 +21,7 @@ data "secrethub_secret" "db_password" {
 ## Argument Reference
 
 * `path` - (Required) The path where the secret is stored. To use a specific version, append the version number to the path, separated by a colon (path:version). Defaults to the latest version.
+* `path_prefix` - **Deprecated** (Optional) Overrides the `path_prefix` defined in the provider.
 
 ## Attributes Reference
 

--- a/website/docs/r/secret.html.markdown
+++ b/website/docs/r/secret.html.markdown
@@ -39,6 +39,7 @@ resource "secrethub_secret" "db_password" {
 The following arguments are supported:
 
 * `path` - (Required) The path where the secret will be stored.
+* `path_prefix` - **Deprecated** (Optional) Overrides the `path_prefix` defined in the provider.
 * `value` - (Optional) The secret contents. Either `value` or `generate` must be defined.
 * `generate` - (Optional) Settings for autogenerating a secret. Either `value` or `generate` must be defined.
 


### PR DESCRIPTION
See [the Terraform docs](https://www.terraform.io/docs/extend/best-practices/deprecations.html#provider-attribute-removal)