### PR TITLE
Rename access_rule dir_path to dir

### DIFF
--- a/secrethub/resource_access_rule.go
+++ b/secrethub/resource_access_rule.go
@@ -15,7 +15,7 @@ func resourceAccessRule() *schema.Resource {
 		Update: resourceAccessRuleSet,
 		Delete: resourceAccessRuleDelete,
 		Schema: map[string]*schema.Schema{
-			"dir_path": {
+			"dir": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
@@ -40,7 +40,7 @@ func resourceAccessRuleSet(d *schema.ResourceData, m interface{}) error {
 	provider := m.(providerMeta)
 	client := *provider.client
 
-	path := d.Get("dir_path").(string)
+	path := d.Get("dir").(string)
 	permission := d.Get("permission").(string)
 	account := d.Get("account_name").(string)
 
@@ -83,7 +83,7 @@ func resourceAccessRuleDelete(d *schema.ResourceData, m interface{}) error {
 	provider := m.(providerMeta)
 	client := *provider.client
 
-	path := d.Get("dir_path").(string)
+	path := d.Get("dir").(string)
 	account := d.Get("account_name").(string)
 
 	return client.AccessRules().Delete(path, account)

--- a/secrethub/resource_access_rule_test.go
+++ b/secrethub/resource_access_rule_test.go
@@ -16,7 +16,7 @@ func TestAccResourceAccessRule(t *testing.T) {
 
 	config := fmt.Sprintf(`
 		resource "secrethub_access_rule" "test" {
-			dir_path = "%s"
+			dir = "%s"
 			account_name = "%s"
 			permission = "%s"
 		}
@@ -48,7 +48,7 @@ func TestAccAccessRuleForService(t *testing.T) {
 		}
 
 		resource "secrethub_access_rule" "test" {
-			dir_path = "%s"
+			dir = "%s"
 			account_name = "${secrethub_service.test.id}"
 			permission = "%s"
 		}

--- a/website/docs/r/access_rule.html.markdown
+++ b/website/docs/r/access_rule.html.markdown
@@ -15,5 +15,5 @@ This resource allows you to create and manage access rules, to give users and/or
 The following arguments are supported:
 
 * `account_name` - (Required) The name of the account (username or service ID) for which the permission holds.
-* `dir_path` - (Required) The path of the directory on which the permission holds.
+* `dir` - (Required) The path of the directory on which the permission holds.
 * `permission` - (Required) The permission that the account has on the given directory: read, write or admin


### PR DESCRIPTION
This is consistent with the repo field of service, which is called `repo` and not `repo_path`.