### PR TITLE
Add import functionality for access rules and error on creation of an existing access rule

### DIFF
--- a/secrethub/resource_access_rule.go
+++ b/secrethub/resource_access_rule.go
@@ -73,9 +73,6 @@ func resourceAccessRuleUpdate(d *schema.ResourceData, m interface{}) error {
 	account := d.Get("account_name").(string)
 
 	_, err := client.AccessRules().Set(path, permission, account)
-
-	d.SetId(path + ":" + account)
-
 	return err
 }
 

--- a/secrethub/resource_access_rule.go
+++ b/secrethub/resource_access_rule.go
@@ -55,10 +55,13 @@ func resourceAccessRuleCreate(d *schema.ResourceData, m interface{}) error {
 	}
 
 	_, err = client.AccessRules().Set(path, permission, account)
+	if err != nil {
+		return err
+	}
 
 	d.SetId(path + ":" + account)
 
-	return err
+	return nil
 }
 
 func resourceAccessRuleUpdate(d *schema.ResourceData, m interface{}) error {

--- a/secrethub/resource_access_rule_test.go
+++ b/secrethub/resource_access_rule_test.go
@@ -32,6 +32,10 @@ func TestAccResourceAccessRule(t *testing.T) {
 					checkAccessRuleExistsRemotely(repoPath, accountName, permission),
 				),
 			},
+			{
+				ImportState:  true,
+				ResourceName: "secrethub_access_rule.test",
+			},
 		},
 	})
 }
@@ -105,4 +109,3 @@ func checkAccessRuleForServiceExistsRemotely(repoPath string, serviceDescription
 		return fmt.Errorf("cannot find service in repo %s with description %s", repoPath, serviceDescription)
 	}
 }
-

--- a/website/docs/r/access_rule.html.markdown
+++ b/website/docs/r/access_rule.html.markdown
@@ -17,3 +17,7 @@ The following arguments are supported:
 * `account_name` - (Required) The name of the account (username or service ID) for which the permission holds.
 * `dir_path` - (Required) The path of the directory on which the permission holds.
 * `permission` - (Required) The permission that the account has on the given directory: read, write or admin
+
+## Import
+
+Access rules can be imported using the id: `<path>:<account_name>` e.g. `path/to/dir:alice`.


### PR DESCRIPTION
When creating an access rule, it is now checked that no access rule for the account on the given path exists yet. Instead, the access rule should be explicitly imported, to prevent accidentally overwriting access rules.