### PR TITLE
Remove references to beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   </a>
 </p>
 <h1 align="center">
-  <i>Provider<sup><a href="#beta">BETA</a></sup></i>
+  <i>Provider</i>
 </h1>
 
 [![GoDoc](https://godoc.org/github.com/secrethub/terraform-provider-secrethub?status.svg)][godoc]
@@ -62,16 +62,12 @@ Have a look at the [reference docs](https://secrethub.io/docs/reference/terrafor
 
 Check out the [step-by-step integration guide](https://secrethub.io/docs/terraform/) to get started.
 
-A detailed use case is described in the [beta announcement](https://secrethub.io/blog/secret-management-for-terraform/).
+A detailed use case is described in the [original announcement](https://secrethub.io/blog/secret-management-for-terraform/).
 There are also some [examples](/examples) in this repo.
 
-## BETA
+## Support
 
-This project is [currently in beta](https://secrethub.io/blog/secret-management-for-terraform/) and we'd love your feedback! Check out the [issues](https://github.com/secrethub/terraform-provider-secrethub/issues) and feel free suggest cool ideas, use cases, or improvements.
-
-Because it's still in beta, you can expect to see some changes introduced. Pull requests are very welcome.
-
-For support, send us a message on the `#terraform` channel on [<img src="https://discordapp.com/assets/2c21aeda16de354ba5334551a883b481.png" alt="Discord" width="20px"> Discord](https://discord.gg/wcxV5RD) or send an email to [terraform@secrethub.io](mailto:terraform@secrethub.io)
+If you need help, send us a message on the `#terraform` channel on [<img src="https://discordapp.com/assets/2c21aeda16de354ba5334551a883b481.png" alt="Discord" width="20px"> Discord](https://discord.gg/wcxV5RD) or send an email to [terraform@secrethub.io](mailto:terraform@secrethub.io)
 
 ## Development
 


### PR DESCRIPTION
We're now officially supporting the Terraform Provider and it's no longer in beta.