### PR TITLE
Standardize release archives

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,8 +8,9 @@ builds:
       - linux
       - darwin
       - windows
-    goarch:
-      - amd64
+    ignore:
+      - goos: darwin
+        goarch: 386
 
 archive:
   name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,9 +13,6 @@ builds:
 
 archive:
   name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}"
-  replacements:
-    amd64: 64-bit
-    darwin: macOS
   format_overrides:
     - goos: windows
       format: zip


### PR DESCRIPTION
This does two things:
1. Remove the `64-bit` override in the release archive names. Now they are called `amd64` again instead of `64-bit`, as is standard for Terraform Providers.
2. Also release i386 versions for Windows and Linux.