### PR TITLE
Remove deprecated path_prefix

### DIFF
--- a/secrethub/data_source_secret.go
+++ b/secrethub/data_source_secret.go
@@ -13,12 +13,6 @@ func dataSourceSecret() *schema.Resource {
 				Required:    true,
 				Description: "The path where the secret is stored. To use a specific version, append the version number to the path, separated by a colon (path:version). Defaults to the latest version.",
 			},
-			"path_prefix": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "Overrides the `path_prefix` defined in the provider.",
-				Deprecated:  "Deprecated in favor of Terraform's native variables",
-			},
 			"version": {
 				Type:        schema.TypeInt,
 				Computed:    true,
@@ -38,7 +32,7 @@ func dataSourceSecretRead(d *schema.ResourceData, m interface{}) error {
 	provider := m.(providerMeta)
 	client := *provider.client
 
-	path := getSecretPath(d, &provider)
+	path := d.Get("path").(string)
 
 	secret, err := client.Secrets().Versions().GetWithData(path)
 	if err != nil {
@@ -54,7 +48,7 @@ func dataSourceSecretRead(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 
-	d.SetId(string(path))
+	d.SetId(path)
 
 	return nil
 }

--- a/secrethub/data_source_secret_test.go
+++ b/secrethub/data_source_secret_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccDataSourceSecret_absPath(t *testing.T) {
+func TestAccDataSourceSecret_PathUnversioned(t *testing.T) {
 	config := fmt.Sprintf(`
 		resource "secrethub_secret" "%v" {
 			path = "%v"
@@ -42,7 +42,7 @@ func TestAccDataSourceSecret_absPath(t *testing.T) {
 	})
 }
 
-func TestAccDataSourceSecret_absPathVersioned(t *testing.T) {
+func TestAccDataSourceSecret_PathVersioned(t *testing.T) {
 	configInit := fmt.Sprintf(`
 		resource "secrethub_secret" "%v" {
 			path = "%v"

--- a/secrethub/data_source_secret_test.go
+++ b/secrethub/data_source_secret_test.go
@@ -92,37 +92,3 @@ func TestAccDataSourceSecret_absPathVersioned(t *testing.T) {
 		},
 	})
 }
-
-func TestAccDataSourceSecret_prefPath(t *testing.T) {
-	config := fmt.Sprintf(`
-		provider "secrethub" {
-			path_prefix = "%v/%v"
-		}
-
-		resource "secrethub_secret" "%v" {
-			path = "%v"
-			value = "secretpassword"
-		}
-
-		data "secrethub_secret" "%v" {
-			path = secrethub_secret.%v.path
-		}
-	`, testAcc.namespace, testAcc.repository, testAcc.secretName, testAcc.secretName, testAcc.secretName, testAcc.secretName)
-
-	resource.Test(t, resource.TestCase{
-		Providers: testAccProviders,
-		PreCheck:  testAccPreCheck(t),
-		Steps: []resource.TestStep{
-			{
-				Config: config,
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						fmt.Sprintf("data.secrethub_secret.%v", testAcc.secretName),
-						"value",
-						"secretpassword",
-					),
-				),
-			},
-		},
-	})
-}

--- a/secrethub/provider.go
+++ b/secrethub/provider.go
@@ -25,12 +25,6 @@ func Provider() terraform.ResourceProvider {
 				DefaultFunc: schema.EnvDefaultFunc("SECRETHUB_CREDENTIAL_PASSPHRASE", nil),
 				Description: "Passphrase to unlock the authentication passed in `credential`. Can also be sourced from SECRETHUB_CREDENTIAL_PASSPHRASE.",
 			},
-			"path_prefix": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "The default value to prefix path values with. If set, paths for resources and data sources will be prefixed with the given prefix, allowing you to use relative paths instead. If left blank, every path must be absolute (namespace/repository/[dir/]secret_name).",
-				Deprecated:  "Deprecated in favor of Terraform's native variables",
-			},
 		},
 		ConfigureFunc: configureProvider,
 		ResourcesMap: map[string]*schema.Resource{
@@ -65,11 +59,9 @@ func configureProvider(d *schema.ResourceData) (interface{}, error) {
 		return nil, err
 	}
 
-	pathPrefix := d.Get("path_prefix").(string)
-	return providerMeta{client, pathPrefix}, nil
+	return providerMeta{client}, nil
 }
 
 type providerMeta struct {
-	client     *secrethub.Client
-	pathPrefix string
+	client *secrethub.Client
 }

--- a/secrethub/resource_secret_test.go
+++ b/secrethub/resource_secret_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccResourceSecret_writeAbsPath(t *testing.T) {
+func TestAccResourceSecret_writePath(t *testing.T) {
 	config := fmt.Sprintf(`
 		resource "secrethub_secret" "%v" {
 			path = "%v"

--- a/secrethub/resource_secret_test.go
+++ b/secrethub/resource_secret_test.go
@@ -34,59 +34,6 @@ func TestAccResourceSecret_writeAbsPath(t *testing.T) {
 	})
 }
 
-func TestAccResourceSecret_writePrefPath(t *testing.T) {
-	config := fmt.Sprintf(`
-		provider "secrethub" {
-			path_prefix = "%v"
-		}
-
-		resource "secrethub_secret" "%v" {
-			path = "%v/%v"
-			value = "secretpassword"
-		}
-	`, testAcc.namespace, testAcc.secretName, testAcc.repository, testAcc.secretName)
-
-	resource.Test(t, resource.TestCase{
-		Providers: testAccProviders,
-		PreCheck:  testAccPreCheck(t),
-		Steps: []resource.TestStep{
-			{
-				Config: config,
-				Check: resource.ComposeTestCheckFunc(
-					checkSecretExistsRemotely(testAcc),
-				),
-			},
-		},
-	})
-}
-
-func TestAccResourceSecret_writePrefPathOverride(t *testing.T) {
-	config := fmt.Sprintf(`
-		provider "secrethub" {
-			path_prefix = "override_me"
-		}
-		
-		resource "secrethub_secret" "%v" {
-			path_prefix = "%v"
-			path = "%v/%v"
-			value = "secretpassword"
-		}
-	`, testAcc.secretName, testAcc.namespace, testAcc.repository, testAcc.secretName)
-
-	resource.Test(t, resource.TestCase{
-		Providers: testAccProviders,
-		PreCheck:  testAccPreCheck(t),
-		Steps: []resource.TestStep{
-			{
-				Config: config,
-				Check: resource.ComposeTestCheckFunc(
-					checkSecretExistsRemotely(testAcc),
-				),
-			},
-		},
-	})
-}
-
 func TestAccResourceSecret_generate(t *testing.T) {
 	configInit := fmt.Sprintf(`
 		resource "secrethub_secret" "%v" {

--- a/website/docs/d/secret.html.markdown
+++ b/website/docs/d/secret.html.markdown
@@ -21,7 +21,6 @@ data "secrethub_secret" "db_password" {
 ## Argument Reference
 
 * `path` - (Required) The path where the secret is stored. To use a specific version, append the version number to the path, separated by a colon (path:version). Defaults to the latest version.
-* `path_prefix` - **Deprecated** (Optional) Overrides the `path_prefix` defined in the provider.
 
 ## Attributes Reference
 

--- a/website/docs/r/secret.html.markdown
+++ b/website/docs/r/secret.html.markdown
@@ -54,7 +54,6 @@ resource "secrethub_secret" "db_password" {
 The following arguments are supported:
 
 * `path` - (Required) The path where the secret will be stored.
-* `path_prefix` - **Deprecated** (Optional) Overrides the `path_prefix` defined in the provider.
 * `value` - (Optional) The secret contents. Either `value` or `generate` must be defined.
 * `generate` - (Optional) Settings for autogenerating a secret. Either `value` or `generate` must be defined.
 


### PR DESCRIPTION
This field was previously deprecated. For the `v1.0.0` release it will be dropped.