### PR TITLE
Use SecretHub to fetch the acceptance test secrets to master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,12 @@
 version: 2.1
+orbs:
+  secrethub: secrethub/cli@1.0.0
 jobs:
   build:
     docker:
       - image: circleci/golang:1.13
     steps:
+      - secrethub/install
       - checkout
       - restore_cache:
           keys:
@@ -13,6 +16,14 @@ jobs:
           key: go-modules-{{ checksum "go.mod" }}
           paths:
             - /go/pkg/mod
-      - run: make testacc
+      - secrethub/exec:
+          step-name: Run acceptance tests
+          command: make testacc
+          # SecretHub credential to use in the acceptance tests
+          flags: -e SECRETHUB_CREDENTIAL=secrethub/terraform-provider/testacc/secrethub/credential
     environment:
       GOPROXY: "https://proxy.golang.org"
+      # AWS access key id to use in the acceptance tests
+      AWS_ACCESS_KEY_ID: secrethub://secrethub/terraform-provider/testacc/aws/access_key_id
+      # AWS secret access key to use in the acceptance tests
+      AWS_SECRET_ACCESS_KEY: secrethub://secrethub/terraform-provider/testacc/aws/secret_access_key

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,11 +18,13 @@ jobs:
             - /go/pkg/mod
       - secrethub/exec:
           step-name: Run acceptance tests
-          command: make testacc
-          # SecretHub credential to use in the acceptance tests
-          flags: -e SECRETHUB_CREDENTIAL=secrethub/terraform-provider/testacc/secrethub/credential
+          command: |
+            SECRETHUB_CREDENTIAL=$TF_ACC_SECRETHUB_CREDENTIAL
+            make testacc
     environment:
       GOPROXY: "https://proxy.golang.org"
+      # SecretHub credential to use in the acceptance tests
+      TF_ACC_SECRETHUB_CREDENTIAL: secrethub://secrethub/terraform-provider/testacc/secrethub/credential
       # AWS access key id to use in the acceptance tests
       AWS_ACCESS_KEY_ID: secrethub://secrethub/terraform-provider/testacc/aws/access_key_id
       # AWS secret access key to use in the acceptance tests


### PR DESCRIPTION
#83 to `master`, so that `master` and `develop` depend on the same CircleCI secrets again.

Using SecretHub solves this problem, as the secret references are changed together with the pipeline in the source code, so we'll never be out-of-sync again :smile: