### PR TITLE
Make the credential field optional

### DIFF
--- a/secrethub/provider.go
+++ b/secrethub/provider.go
@@ -60,12 +60,6 @@ func configureProvider(d *schema.ResourceData) (interface{}, error) {
 		return nil, err
 	}
 
-	credential := client.DefaultCredential()
-	_, err = credential.Read()
-	if err != nil {
-		return nil, err
-	}
-
 	return providerMeta{client}, nil
 }
 

--- a/secrethub/provider.go
+++ b/secrethub/provider.go
@@ -15,7 +15,7 @@ func Provider() terraform.ResourceProvider {
 		Schema: map[string]*schema.Schema{
 			"credential": {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("SECRETHUB_CREDENTIAL", nil),
 				Description: "Credential to use for SecretHub authentication. Can also be sourced from SECRETHUB_CREDENTIAL.",
 			},

--- a/secrethub/provider.go
+++ b/secrethub/provider.go
@@ -60,6 +60,12 @@ func configureProvider(d *schema.ResourceData) (interface{}, error) {
 		return nil, err
 	}
 
+	credential := client.DefaultCredential()
+	_, err = credential.Read()
+	if err != nil {
+		return nil, err
+	}
+
 	return providerMeta{client}, nil
 }
 


### PR DESCRIPTION
This PR makes providing the SecretHub credential optional.

If it is not provided, the client will be constructed without any options, therefore detecting the credential in the same way the CLI does.

In case no credential is found, the provider fails early instead of using an unauthenticated client.