### PR TITLE
Update .goreleaser.yml to release to all recommended architectures

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,6 +5,7 @@ builds:
     env:
       - CGO_ENABLED=0
     goos:
+      - freebsd
       - linux
       - darwin
       - windows

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,9 +8,14 @@ builds:
       - linux
       - darwin
       - windows
+    goarch:
+      - amd64
+      - '386'
+      - arm
+      - arm64
     ignore:
       - goos: darwin
-        goarch: 386
+        goarch: '386'
 
 archives:
   - name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}"


### PR DESCRIPTION
This PR updates the goreleaser to comply with the terraform recommendations found on [this page](https://www.terraform.io/docs/registry/providers/os-arch.html)

Note that the default values of goarch were ['386', 'amd64'].