### PR TITLE
Bring .goreleaser.yml up to TF standard

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -29,7 +29,8 @@ archives:
   - format: zip
     name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
   # The following archives are deprecated and will be dropped for releases starting April 2021:
-  - name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}"
+  - id: backwards-compatibility
+    name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}"
     format_overrides:
       - goos: windows
         format: zip

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,7 +8,7 @@ builds:
     flags:
       - -trimpath
     ldflags:
-      - '-s -w'
+      - '-s -w -X github.com/secrethub/terraform-provider-secrethub/secrethub.version=v{{.Version}}'
     goos:
       - freebsd
       - linux

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,9 +1,14 @@
 project_name: terraform-provider-secrethub
 
 builds:
-  - binary: "{{ .ProjectName }}_{{ .Tag }}"
+  - binary: "{{ .ProjectName }}_v{{ .Version }}"
     env:
       - CGO_ENABLED=0
+    mod_timestamp: '{{ .CommitTimestamp }}'
+    flags:
+      - -trimpath
+    ldflags:
+      - '-s -w'
     goos:
       - freebsd
       - linux
@@ -21,6 +26,9 @@ builds:
         goarch: arm64
 
 archives:
+  - format: zip
+    name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+  # The following archives are deprecated and will be dropped for releases starting April 2021:
   - name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}"
     format_overrides:
       - goos: windows


### PR DESCRIPTION
Some options as suggested by Terraform were not yet included. Also the archive names did not adhere to the naming convention.