### PR TITLE
Remove secret at old path when secret path is updated

### DIFF
--- a/secrethub/resource_secret.go
+++ b/secrethub/resource_secret.go
@@ -21,6 +21,7 @@ func resourceSecret() *schema.Resource {
 			"path": {
 				Type:        schema.TypeString,
 				Required:    true,
+				ForceNew:    true,
 				Description: "The path where the secret will be stored.",
 			},
 			"version": {


### PR DESCRIPTION
Previously, when updating the `path` of a `secrethub_secret resource` the secret would be created in the new location, but the secret would also remain at the old location. This commit changes the behavior so that the secret is removed in the old location when the path of the secret resource is changed.