### PR TITLE
Allow setting credential_passphrase without setting credential

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/secrethub/terraform-provider-secrethub
 require (
 	github.com/aws/aws-sdk-go v1.25.49
 	github.com/hashicorp/terraform v0.12.3
-	github.com/secrethub/secrethub-go v0.32.0
+	github.com/secrethub/secrethub-go v0.32.1
 )
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -353,6 +353,8 @@ github.com/secrethub/secrethub-go v0.30.0 h1:Nh1twPDwPbYQj/cYc1NG+j7sv76LZiXLPov
 github.com/secrethub/secrethub-go v0.30.0/go.mod h1:tDeBtyjfFQX3UqgaZfY+H4dYkcGfiVzrwLDf0XtfOrw=
 github.com/secrethub/secrethub-go v0.32.0 h1:hypQsdyCpocd8v9xo3lYvP5viOkjDLKx51z62/obKoU=
 github.com/secrethub/secrethub-go v0.32.0/go.mod h1:ZIco8Y0G0Pi0Vb7pQROjvEKgSreZiRMLhAbzWUneUSQ=
+github.com/secrethub/secrethub-go v0.32.1 h1:5Ux44/0Ey6XKpkmzMOtxzx0T85v30k0bADnAGa27eBY=
+github.com/secrethub/secrethub-go v0.32.1/go.mod h1:ZIco8Y0G0Pi0Vb7pQROjvEKgSreZiRMLhAbzWUneUSQ=
 github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/shurcooL/component v0.0.0-20170202220835-f88ec8f54cc4/go.mod h1:XhFIlyj5a1fBNx5aJTbKoIq0mNaPvOagO+HjB3EtxrY=

--- a/secrethub/provider.go
+++ b/secrethub/provider.go
@@ -23,7 +23,7 @@ func Provider() terraform.ResourceProvider {
 				Type:        schema.TypeString,
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("SECRETHUB_CREDENTIAL_PASSPHRASE", nil),
-				Description: "Passphrase to unlock the authentication passed in `credential`. Can also be sourced from SECRETHUB_CREDENTIAL_PASSPHRASE.",
+				Description: "Passphrase to unlock the credential. Can also be sourced from SECRETHUB_CREDENTIAL_PASSPHRASE.",
 			},
 		},
 		ConfigureFunc: configureProvider,
@@ -58,6 +58,8 @@ func configureProvider(d *schema.ResourceData) (interface{}, error) {
 			provider = keyProvider.Passphrase(credentials.FromString(passphrase))
 		}
 		options = append(options, secrethub.WithCredentials(provider))
+	} else if passphrase != "" {
+		options = append(options, secrethub.WithDefaultPassphraseReader(credentials.FromString(passphrase)))
 	}
 
 	client, err := secrethub.NewClient(options...)

--- a/secrethub/provider.go
+++ b/secrethub/provider.go
@@ -52,7 +52,12 @@ func configureProvider(d *schema.ResourceData) (interface{}, error) {
 	}
 
 	if credRaw != "" {
-		options = append(options, secrethub.WithCredentials(credentials.UseKey(credentials.FromString(credRaw)).Passphrase(credentials.FromString(passphrase))))
+		keyProvider := credentials.UseKey(credentials.FromString(credRaw))
+		var provider credentials.Provider = keyProvider
+		if passphrase != "" {
+			provider = keyProvider.Passphrase(credentials.FromString(passphrase))
+		}
+		options = append(options, secrethub.WithCredentials(provider))
 	}
 
 	client, err := secrethub.NewClient(options...)


### PR DESCRIPTION
An example usecase would be when running Terraform locally. You can have your personal credential in `~/.secrethub/credential`
auto-detected and use a tfvar to pass the credential passphrase. Then Terraform would prompt for your passphrase on running terraform commands:

```hcl
variable "secrethub_credential_passphrase" {
  type = string
  description = "Passphrase for the auto-detected SecretHub credential (leave empty if your credential is not passphrase protected)"
}

provider "secrethub" {
  credential_passphrase = var.secrethub_credential_passphrase
}
```

---

Additionally, this PR improves the error message on missing credential passphrases.

Previously, it showed:
```
passphrase is incorrect (credentials.cannot_decrypt_credential)
```
now it will show:
```
credential is password-protected. Configure a credential passphrase through the SECRETHUB_CREDENTIAL_PASSPHRASE environment variable or use a credential that is not password-protected (credentials.credential_passphrase_required)
```