### PR TITLE
Add caching to lint job and increase allowed timeout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,24 @@ jobs:
       - image: golangci/golangci-lint:v1.27.0-alpine
     steps:
       - checkout
+      - restore_cache:
+          keys:
+            - go-modules-{{ checksum "go.mod" }}
+      - run: go mod download
+      - save_cache:
+          key: go-modules-{{ checksum "go.mod" }}
+          paths:
+            - /go/pkg/mod
+      - restore_cache:
+          keys:
+            - golangci-lint-{{ .Branch }}
+            - golangci-lint-develop
       - run: golangci-lint run
+      - save_cache:
+          key: golangci-lint-{{ .Branch }}
+          paths:
+            - ~/.cache/golangci-lint
+            - ~/.cache/go-build
   build:
     docker:
       - image: circleci/golang:1.13

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,3 +24,5 @@ linters:
     - unconvert
 disable-all: true
 exclude-use-defaults: false
+run:
+  timeout: 5m


### PR DESCRIPTION
We're running into a lint timeout on https://github.com/secrethub/terraform-provider-secrethub/pull/127, so I'm suggesting to apply the same fixes as in https://github.com/secrethub/secrethub-cli/pull/371